### PR TITLE
center x-logo if no additionnal logo is provided

### DIFF
--- a/cover.typ
+++ b/cover.typ
@@ -77,11 +77,17 @@
 
   set image(height: logo-height)
 
-  grid(
-    columns: (1fr, 1fr), align: center + horizon,
-    if (logo != none) { logo } else { smallcaps("Insert your logo") },
-    image(path-logo-x)
-  )
+  if (logo != none) {
+    grid(
+      columns: (1fr, 1fr), align: center + horizon,
+      logo, image(path-logo-x)
+    )
+  } else {
+    grid(
+      columns: (1fr), align: center + horizon,
+      image(path-logo-x)
+    )
+  }
 
 }
 


### PR DESCRIPTION
This is to mimic the LaTeX package's default behaviour when no logo is given. Did not test the change made though (idk how to).